### PR TITLE
Update test assembly path to net10.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,5 +27,5 @@ jobs:
           # Build Tests
           dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1 && \
           # Run Tests
-          dotnet test ./tests/bin/Release/net9.0/Tests.dll
+          dotnet test ./tests/bin/Release/net10.0/Tests.dll
 


### PR DESCRIPTION
The tests project targets net10.0 but the workflow ran `dotnet test` against the net9.0 output path, causing "The test source file ... net9.0/Tests.dll was not found" and a red build. Point the test path to net10.0.